### PR TITLE
Update dependency Cake.Core to v0.30.0

### DIFF
--- a/Cake.XComponent/Cake.XComponent.csproj
+++ b/Cake.XComponent/Cake.XComponent.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Core" Version="0.29.0" PrivateAssets="All" />
+    <PackageReference Include="Cake.Core" Version="0.30.0" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
<p>This Pull Request updates dependency <a href="https://renovatebot.com/gh/cake-build/cake">Cake.Core</a> from <code>v0.29.0</code> to <code>v0.30.0</code></p>
<p><details><br />
<summary>Release Notes</summary></p>
<h3 id="v0300httpsgithubcomcake-buildcakeblobmasterchangelogmdnew-in-0300-released-20180822"><a href="https://renovatebot.com/gh/cake-build/cake/blob/master/CHANGELOG.md#New-in-0300-Released-20180822"><code>v0.30.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/cake-build/cake/compare/v0.29.0…v0.30.0">Compare Source</a></p>
<ul>
<li>2067 Publish as .NET Core Global Tool.</li>
<li>2238 Add repository metadata to NuGet packages.</li>
<li>2234 Remove mono argument from Argument Parser.</li>
<li>2211 DotNetCorePublishSettings doesn't contain --no-build flag support introduced in .NET Core SDK 2.1.</li>
<li>2146 Enabling initializer syntax for all collection properties.</li>
<li>1401 Support for dotCover configuration file.</li>
<li>2233 Add bootstrap argument to Help Command.</li>
<li>2232 Add exclusive argument to Help Command.</li>
<li>2220 Incorrect documentation for InnoSetup Alias.</li>
<li>2228 CakeTaskExtensions are no longer accessible.</li>
<li>2224 Add option for ProcessSettings to opt out of working directory magic.</li>
<li>2214 Cake.CoreCLR can't handle whitespace in path.</li>
<li>2208 WithCriteria does not work with 'DryRun' (WhatIf flag).</li>
<li>2207 NuGet hang due to bug in NuGet 4.6.0.</li>
</ul>
<hr />
<p></details></p>
<hr />
<p>This PR has been generated by <a href="https://renovatebot.com">Renovate Bot</a>.</p>